### PR TITLE
Generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: clean
 CFLAGS=-O2 -Wall -Wpedantic -Wextra -pthread -ggdb3 -I./crypt
-OBJ=brute.o iter.o rec.o common.o main.o multi.o queue.o single.o
+OBJ=brute.o iter.o rec.o common.o main.o multi.o queue.o single.o gen.o
 TARGET=main
 LIBS+=crypt/libcrypt.a
 

--- a/common.c
+++ b/common.c
@@ -33,7 +33,7 @@ create_threads (pthread_t *threads, int number_of_threads, void *func (void *),
       ++active_threads;
 
   if (active_threads == 0)
-    print_error ("Could not create a single thread\n"); 
+    print_error ("Could not create a single thread\n");
 
   return active_threads;
 }

--- a/common.c
+++ b/common.c
@@ -22,3 +22,18 @@ cleanup_mutex_unlock (void *mutex)
 {
   pthread_mutex_unlock ((pthread_mutex_t *)mutex);
 }
+
+int
+create_threads (pthread_t *threads, int number_of_threads, void *func (void *),
+                void *context)
+{
+  int active_threads = 0;
+  for (int i = 0; i < number_of_threads; ++i)
+    if (pthread_create (&threads[i], NULL, func, context) == 0)
+      ++active_threads;
+
+  if (active_threads == 0)
+    print_error ("Could not create a single thread\n"); 
+
+  return active_threads;
+}

--- a/common.h
+++ b/common.h
@@ -25,5 +25,7 @@ typedef enum status_t
 
 status_t print_error (const char *msg, ...);
 void cleanup_mutex_unlock (void *mutex);
+int create_threads (pthread_t *threads, int number_of_threads,
+                    void *func (void *), void *context);
 
 #endif // COMMON_H

--- a/config.h
+++ b/config.h
@@ -5,6 +5,7 @@ typedef enum
 {
   RM_SINGLE,
   RM_MULTI,
+  RM_GENERATOR,
 } run_mode_t;
 
 typedef enum

--- a/gen.c
+++ b/gen.c
@@ -57,22 +57,11 @@ gen_worker (void *context)
       if (gen_context->cancelled || gen_context->password[0] != 0)
         break;
 
-      if (pthread_mutex_lock (&gen_context->mutex) != 0)
-        {
-          print_error ("Could not lock a mutex\n");
-          return (NULL);
-        }
-
       if (st_password_check (&current_task, &st_context))
         {
           memcpy (gen_context->password, current_task.password,
                   sizeof (current_task.password));
           gen_context->cancelled = true;
-        }
-
-      if (pthread_mutex_unlock (&gen_context->mutex) != 0)
-        {
-          print_error ("Could not unlock a mutex\n");
         }
     }
   return (NULL);

--- a/gen.c
+++ b/gen.c
@@ -45,11 +45,14 @@ generator (void *context)
           print_error ("Could not lock a mutex\n");
           return (NULL);
         }
-      pthread_cleanup_push (cleanup_mutex_unlock, &gen_context->mutex);
 
       gen_context->cancelled = !iter_state_next (&gen_context->state);
 
-      pthread_cleanup_pop (!0);
+      if (pthread_mutex_unlock (&gen_context->mutex) != 0)
+        {
+          print_error ("Could not unlock a mutex\n");
+          return (NULL);
+        }
 
       task->to = task->from;
       task->from = 0;

--- a/gen.c
+++ b/gen.c
@@ -56,15 +56,24 @@ gen_worker (void *context)
 
       if (gen_context->cancelled || gen_context->password[0] != 0)
         break;
-      pthread_mutex_lock (&gen_context->mutex);
-      printf ("%s\n", current_task.password);
+
+      if (pthread_mutex_lock (&gen_context->mutex) != 0)
+        {
+          print_error ("Could not lock a mutex\n");
+          return (NULL);
+        }
+
       if (st_password_check (&current_task, &st_context))
         {
           memcpy (gen_context->password, current_task.password,
                   sizeof (current_task.password));
           gen_context->cancelled = true;
         }
-      pthread_mutex_unlock (&gen_context->mutex);
+
+      if (pthread_mutex_unlock (&gen_context->mutex) != 0)
+        {
+          print_error ("Could not unlock a mutex\n");
+        }
     }
   return (NULL);
 }

--- a/gen.c
+++ b/gen.c
@@ -46,7 +46,7 @@ gen_worker (void *context)
 
       task_t current_task = *gen_context->state.task;
 
-      if (!gen_context->cancelled || gen_context->password[0] == 0)
+      if (!gen_context->cancelled && gen_context->password[0] == 0)
         gen_context->cancelled = !iter_state_next (&gen_context->state);
 
       if (pthread_mutex_unlock (&gen_context->mutex) != 0)

--- a/gen.c
+++ b/gen.c
@@ -3,6 +3,7 @@
 #include "brute.h"
 #include "single.h"
 #include <string.h>
+#include <stdio.h>
 
 status_t
 gen_context_init (gen_context_t *context, config_t *config, task_t *task)
@@ -53,15 +54,17 @@ gen_worker (void *context)
       if (pthread_mutex_unlock (&gen_context->mutex) != 0)
         {
           print_error ("Could not unlock a mutex\n");
-          return (NULL);
+
         }
 
+      pthread_mutex_lock (&gen_context->mutex);
       if (st_password_check (&current_task, &st_context))
         {
           memcpy (gen_context->password, current_task.password,
                   sizeof (current_task.password));
           gen_context->cancelled = true;
         }
+      pthread_mutex_unlock (&gen_context->mutex);
     }
   return (NULL);
 }

--- a/gen.c
+++ b/gen.c
@@ -1,0 +1,20 @@
+#include "gen.h"
+
+bool
+run_generator (task_t *task, config_t *config)
+{
+  gen_context_t context;
+
+  if (pthread_mutex_init (&context.mutex, NULL) != 0)
+    {
+      print_error ("Could not initialize a mutex\n");
+      return (false);
+    }
+
+  iter_state_init (&context.state, config->alph, task);
+  
+  context.cancelled = false;
+
+  // Remove it later
+  return false;
+}

--- a/gen.c
+++ b/gen.c
@@ -31,8 +31,6 @@ gen_worker (void *context)
 {
   gen_context_t *gen_context = (gen_context_t *)context;
 
-  task_t *task = gen_context->state.task; /* to reduce the amount of code */
-
   st_context_t st_context = {
     .hash = gen_context->config->hash,
     .data = { .initialized = 0 },
@@ -46,8 +44,8 @@ gen_worker (void *context)
           return (NULL);
         }
 
-      task_t current_task;
-      memcpy (current_task.password, task->password, sizeof (task->password));
+      task_t current_task = *gen_context->state.task;
+
       if (!gen_context->cancelled)
         gen_context->cancelled = !iter_state_next (&gen_context->state);
 
@@ -58,6 +56,7 @@ gen_worker (void *context)
         }
 
       pthread_mutex_lock (&gen_context->mutex);
+      printf ("%s\n", current_task.password);
       if (st_password_check (&current_task, &st_context))
         {
           memcpy (gen_context->password, current_task.password,

--- a/gen.c
+++ b/gen.c
@@ -71,19 +71,10 @@ run_generator (task_t *task, config_t *config)
   context.state.task->to = config->length;
 
   pthread_t threads[config->number_of_threads];
-  int active_threads = 0;
-
-  for (int i = 0; i < config->number_of_threads; ++i)
-    if (pthread_create (&threads[i], NULL, generator,
-                        (void *)&context)
-        == 0)
-      ++active_threads;
-
+  int active_threads = create_threads (threads, config->number_of_threads,
+                                       generator, &context);
   if (active_threads == 0)
-    {
-      print_error ("Could not create a single thread\n");
-      return (false);
-    }
+    return (false);
 
   for (int i = 0; i < active_threads; ++i)
     pthread_join (threads[i], NULL);

--- a/gen.c
+++ b/gen.c
@@ -2,7 +2,6 @@
 
 #include "brute.h"
 #include "single.h"
-#include <stdio.h>
 #include <string.h>
 
 status_t
@@ -75,9 +74,12 @@ run_generator (task_t *task, config_t *config)
   if (gen_context_init (&context, config, task) == S_FAILURE)
     return (false);
 
-  pthread_t threads[config->number_of_threads - 1];
-  int active_threads = create_threads (threads, config->number_of_threads - 1,
-                                       gen_worker, &context);
+  int number_of_threads
+      = (config->number_of_threads == 1) ? 1 : config->number_of_threads - 1;
+  pthread_t threads[number_of_threads];
+
+  int active_threads
+      = create_threads (threads, number_of_threads, gen_worker, &context);
   if (active_threads == 0)
     return (false);
 

--- a/gen.c
+++ b/gen.c
@@ -2,6 +2,7 @@
 
 #include "brute.h"
 #include "single.h"
+#include <stdio.h>
 #include <string.h>
 
 status_t
@@ -26,8 +27,11 @@ void *
 generator (void *context)
 {
   gen_context_t *gen_context = (gen_context_t *)context;
-  gen_context->state.task->from = 0;
-  gen_context->state.task->to = gen_context->config->length;
+
+  task_t *task = gen_context->state.task; /* to reduce the amount of code */
+
+  task->from = 0;
+  task->to = gen_context->config->length;
 
   st_context_t st_context = {
     .hash = gen_context->config->hash,
@@ -47,14 +51,12 @@ generator (void *context)
 
       pthread_cleanup_pop (!0);
 
-      gen_context->state.task->to = gen_context->state.task->from;
-      gen_context->state.task->from = 0;
-      if (brute (gen_context->state.task, gen_context->config,
-                 st_password_check, &st_context))
-        {
-          memcpy (gen_context->password, gen_context->state.task->password,
-                  sizeof (gen_context->state.task->password));
-        }
+      task->to = task->from;
+      task->from = 0;
+
+      if (brute (task, gen_context->config, st_password_check, &st_context))
+        memcpy (gen_context->password, task->password,
+                sizeof (task->password));
     }
   return (NULL);
 }

--- a/gen.c
+++ b/gen.c
@@ -2,8 +2,8 @@
 
 #include "brute.h"
 #include "single.h"
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
 status_t
 gen_context_init (gen_context_t *context, config_t *config, task_t *task)
@@ -46,15 +46,16 @@ gen_worker (void *context)
 
       task_t current_task = *gen_context->state.task;
 
-      if (!gen_context->cancelled)
+      if (!gen_context->cancelled || gen_context->password[0] == 0)
         gen_context->cancelled = !iter_state_next (&gen_context->state);
 
       if (pthread_mutex_unlock (&gen_context->mutex) != 0)
         {
           print_error ("Could not unlock a mutex\n");
-
         }
 
+      if (gen_context->cancelled || gen_context->password[0] != 0)
+        break;
       pthread_mutex_lock (&gen_context->mutex);
       printf ("%s\n", current_task.password);
       if (st_password_check (&current_task, &st_context))

--- a/gen.c
+++ b/gen.c
@@ -1,20 +1,101 @@
 #include "gen.h"
 
+#include "brute.h"
+#include "single.h"
+#include <string.h>
+
+status_t
+gen_context_init (gen_context_t *context, config_t *config, task_t *task)
+{
+  if (pthread_mutex_init (&context->mutex, NULL) != 0)
+    {
+      print_error ("Could not initialize a mutex\n");
+      return (S_FAILURE);
+    }
+
+  iter_state_init (&context->state, config->alph, task);
+
+  context->config = config;
+  context->cancelled = false;
+  context->password[0] = 0;
+
+  return (S_SUCCESS);
+}
+
+void *
+generator (void *context)
+{
+  gen_context_t *gen_context = (gen_context_t *)context;
+  gen_context->state.task->from = 0;
+  gen_context->state.task->to = gen_context->config->length;
+
+  st_context_t st_context = {
+    .hash = gen_context->config->hash,
+    .data = { .initialized = 0 },
+  };
+
+  while (!gen_context->cancelled && gen_context->password[0] == 0)
+    {
+      if (pthread_mutex_lock (&gen_context->mutex) != 0)
+        {
+          print_error ("Could not lock a mutex\n");
+          return (NULL);
+        }
+      pthread_cleanup_push (cleanup_mutex_unlock, &gen_context->mutex);
+
+      gen_context->cancelled = !iter_state_next (&gen_context->state);
+
+      pthread_cleanup_pop (!0);
+
+      gen_context->state.task->to = gen_context->state.task->from;
+      gen_context->state.task->from = 0;
+      if (brute (gen_context->state.task, gen_context->config,
+                 st_password_check, &st_context))
+        {
+          memcpy (gen_context->password, gen_context->state.task->password,
+                  sizeof (gen_context->state.task->password));
+        }
+    }
+  return (NULL);
+}
+
 bool
 run_generator (task_t *task, config_t *config)
 {
   gen_context_t context;
 
-  if (pthread_mutex_init (&context.mutex, NULL) != 0)
+  if (gen_context_init (&context, config, task) == S_FAILURE)
+    return (false);
+
+  context.state.task->from = 2;
+  context.state.task->to = config->length;
+
+  pthread_t threads[config->number_of_threads];
+  int active_threads = 0;
+
+  for (int i = 0; i < config->number_of_threads; ++i)
+    if (pthread_create (&threads[i], NULL, generator,
+                        (void *)&context)
+        == 0)
+      ++active_threads;
+
+  if (active_threads == 0)
     {
-      print_error ("Could not initialize a mutex\n");
+      print_error ("Could not create a single thread\n");
       return (false);
     }
 
-  iter_state_init (&context.state, config->alph, task);
-  
-  context.cancelled = false;
+  for (int i = 0; i < active_threads; ++i)
+    pthread_join (threads[i], NULL);
 
-  // Remove it later
-  return false;
+  if (pthread_mutex_destroy (&context.mutex) != 0)
+    {
+      print_error ("Could not destroy a mutex\n");
+      return (false);
+    }
+
+  if (context.password[0] != 0)
+    memcpy (task->password, context.password, sizeof (context.password));
+
+  return (context.password[0] != 0);
 }

--- a/gen.h
+++ b/gen.h
@@ -1,8 +1,8 @@
 #ifndef GEN_H
 #define GEN_H
 
-#include "iter.h"
 #include "config.h"
+#include "iter.h"
 #include <pthread.h>
 
 typedef struct gen_context_t

--- a/gen.h
+++ b/gen.h
@@ -10,6 +10,7 @@ typedef struct gen_context_t
   iter_state_t state;
   pthread_mutex_t mutex;
   config_t *config;
+  password_t password;
   bool cancelled;
 } gen_context_t;
 

--- a/gen.h
+++ b/gen.h
@@ -1,0 +1,18 @@
+#ifndef GEN_H
+#define GEN_H
+
+#include "iter.h"
+#include "config.h"
+#include <pthread.h>
+
+typedef struct gen_context_t
+{
+  iter_state_t state;
+  pthread_mutex_t mutex;
+  config_t *config;
+  bool cancelled;
+} gen_context_t;
+
+bool run_generator (task_t *task, config_t *config);
+
+#endif // GEN_H

--- a/main.c
+++ b/main.c
@@ -39,7 +39,7 @@ parse_params (config_t *config, int argc, char *argv[])
           {
             int number_of_cpus = sysconf (_SC_NPROCESSORS_ONLN);
             config->number_of_threads = atoi (optarg);
-            if (config->number_of_threads <= 1
+            if (config->number_of_threads < 1
                 || config->number_of_threads > number_of_cpus)
               {
                 print_error (

--- a/main.c
+++ b/main.c
@@ -1,6 +1,7 @@
 #include "brute.h"
 #include "common.h"
 #include "config.h"
+#include "gen.h"
 #include "multi.h"
 #include "queue.h"
 #include "single.h"
@@ -14,7 +15,7 @@ status_t
 parse_params (config_t *config, int argc, char *argv[])
 {
   int opt = 0;
-  while ((opt = getopt (argc, argv, "l:a:h:t:smir")) != -1)
+  while ((opt = getopt (argc, argv, "l:a:h:t:smgir")) != -1)
     {
       switch (opt)
         {
@@ -53,6 +54,9 @@ parse_params (config_t *config, int argc, char *argv[])
           break;
         case 'm':
           config->run_mode = RM_MULTI;
+          break;
+        case 'g':
+          config->run_mode = RM_GENERATOR;
           break;
         case 'i':
           config->brute_mode = BM_ITER;
@@ -94,6 +98,9 @@ main (int argc, char *argv[])
       break;
     case RM_MULTI:
       is_found = run_multi (&task, &config);
+      break;
+    case RM_GENERATOR:
+      is_found = run_generator (&task, &config);
       break;
     }
 

--- a/multi.c
+++ b/multi.c
@@ -139,18 +139,10 @@ run_multi (task_t *task, config_t *config)
     return (false);
 
   pthread_t threads[config->number_of_threads];
-  int active_threads = 0;
-
-  for (int i = 0; i < config->number_of_threads; ++i)
-    if (pthread_create (&threads[i], NULL, mt_password_check, (void *)&context)
-        == 0)
-      ++active_threads;
-
+  int active_threads = create_threads (threads, config->number_of_threads,
+                                       mt_password_check, &context);
   if (active_threads == 0)
-    {
-      print_error ("Could not create a single thread\n");
-      return (false);
-    }
+    return (false);
 
   // Need to test what is the best task->from value
   task->from = 2;

--- a/multi.c
+++ b/multi.c
@@ -9,6 +9,58 @@
 #include <string.h>
 #include <unistd.h>
 
+status_t
+mt_context_init (mt_context_t *context, config_t *config)
+{
+  if (pthread_mutex_init (&context->mutex, NULL) != 0)
+    {
+      print_error ("Could not initialize a mutex\n");
+      return (S_FAILURE);
+    }
+
+  if (pthread_cond_init (&context->cond_sem, NULL) != 0)
+    {
+      print_error ("Could not initialize a condition variable\n");
+      return (S_FAILURE);
+    }
+
+  if (queue_init (&context->queue) == S_FAILURE)
+    {
+      print_error ("Could not initialize a queue\n");
+      return (S_FAILURE);
+    }
+
+  context->config = config;
+  context->passwords_remaining = 0;
+  context->password[0] = 0;
+
+  return (S_SUCCESS);
+}
+
+status_t
+mt_context_destroy (mt_context_t *context)
+{
+  if (queue_destroy (&context->queue) == S_FAILURE)
+    {
+      print_error ("Could not destroy a queue\n");
+      return (S_FAILURE);
+    }
+
+  if (pthread_cond_destroy (&context->cond_sem) != 0)
+    {
+      print_error ("Could not destroy a condition variable\n");
+      return (S_FAILURE);
+    }
+
+  if (pthread_mutex_destroy (&context->mutex) != 0)
+    {
+      print_error ("Could not destroy a mutex\n");
+      return (S_FAILURE);
+    }
+
+  return (S_SUCCESS);
+}
+
 void *
 mt_password_check (void *context)
 {
@@ -83,27 +135,8 @@ run_multi (task_t *task, config_t *config)
 {
   mt_context_t context;
 
-  if (pthread_mutex_init (&context.mutex, NULL) != 0)
-    {
-      print_error ("Could not initialize a mutex\n");
-      return (false);
-    }
-
-  if (pthread_cond_init (&context.cond_sem, NULL) != 0)
-    {
-      print_error ("Could not initialize a condition variable\n");
-      return (false);
-    }
-
-  if (queue_init (&context.queue) == S_FAILURE)
-    {
-      print_error ("Could not initialize a queue\n");
-      return (false);
-    }
-
-  context.config = config;
-  context.passwords_remaining = 0;
-  context.password[0] = 0;
+  if (mt_context_init (&context, config) == S_FAILURE)
+    return (false);
 
   pthread_t threads[config->number_of_threads];
   int active_threads = 0;
@@ -120,7 +153,7 @@ run_multi (task_t *task, config_t *config)
     }
 
   // Need to test what is the best task->from value
-  task->from = 2; 
+  task->from = 2;
   task->to = config->length;
 
   brute (task, config, queue_push_wrapper, &context);
@@ -153,23 +186,8 @@ run_multi (task_t *task, config_t *config)
   if (context.password[0] != 0)
     memcpy (task->password, context.password, sizeof (context.password));
 
-  if (queue_destroy (&context.queue) == S_FAILURE)
-    {
-      print_error ("Could not destroy a queue\n");
-      return (false);
-    }
-
-  if (pthread_cond_destroy (&context.cond_sem) != 0)
-    {
-      print_error ("Could not destroy a condition variable\n");
-      return (false);
-    }
-
-  if (pthread_mutex_destroy (&context.mutex) != 0)
-    {
-      print_error ("Could not destroy a mutex\n");
-      return (false);
-    }
+  if (mt_context_destroy (&context) == S_FAILURE)
+    return (false);
 
   return (context.password[0] != 0);
 }

--- a/single.h
+++ b/single.h
@@ -3,8 +3,8 @@
 
 #include "common.h"
 #include "config.h"
-#include <stdbool.h>
 #include <crypt.h>
+#include <stdbool.h>
 
 typedef struct st_context_t
 {

--- a/test/encrypt.c
+++ b/test/encrypt.c
@@ -3,8 +3,6 @@
 #include <crypt.h>
 #include <unistd.h>
 
-#define crypt_r __crypt_r
-
 int main(int argc, char **argv) 
 {
   char *password = "abc";


### PR DESCRIPTION
1. Moved `mt_context_t` initialization and destruction to separate functions to improve code readability
2. Moved threads creation to `create_threads ()` function to reduce code repeatability
3. Implemented generator mode

Current problem with the generator mode is that it doesn't stop immediately after password has been found in one of the threads, and because of this, password can be found multiple times.